### PR TITLE
Added arm64 support for generating arm64 docker containers and added arm64 support to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ language: python
 python:
   - "3.7"
   - "3.8"
-
+arch:
+  - amd64
+  - arm64
 # enable docker in Travis
 services:
   - docker
@@ -42,3 +44,4 @@ deploy:
       tags: true
       python: "3.7"
       condition: -n "$TWINE_PASSWORD"
+      arch: amd64

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,13 @@ local_no_proxy ?= ""
 
 name ?= powerfulseal
 version ?= `python setup.py --version`
-tag = $(name):$(version)
+arch1=$(shell uname -m)
+ifeq ($(arch1),x86_64)
+  arch2=amd64
+else ifeq ($(arch1),aarch64)
+  arch2=arm64
+endif
+tag = $(name):$(version)-$(arch2)
 namespace ?= "bloomberg/"
 
 test:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7-slim-buster as builder
 
 # install all the build dependencies
 RUN apt-get update && \
-    apt-get install -y build-essential curl && \
+    apt-get install -y libffi-dev libssl-dev build-essential curl && \
     apt-get clean && \
     apt-get autoclean && \
     apt-get autoremove
@@ -13,7 +13,8 @@ ARG https_proxy
 ARG no_proxy
 
 # download kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl \
+RUN if [ `uname -m` = "aarch64" ] ; then KUBECTL_ARCH="arm64"; else KUBECTL_ARCH="amd64"; fi \
+    && curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/${KUBECTL_ARCH}/kubectl \
     && chmod +x ./kubectl \
     && mv ./kubectl /usr/local/bin/kubectl \
     && kubectl version --client


### PR DESCRIPTION
**Hi**

**Package Owner:** Rahul Aggarwal

**PR change Details:**
**Patch Details** : Following 2 files have been modified :

.travis.yml : arch: arm64 has been added.
/build/Dockerfile : Installed libffi-dev, libssl-dev and kubectl binary for arm64.

**Testing Detail :**
Please find my travis-ci testing jobs here : https://travis-ci.com/github/odidev/powerfulseal/builds/176829381

**Reviewer Comment :** < To be filled by Reviewer >

**PR Description :** Here is my commit message :
1. Added arm64 architecture to .travis.yml file.
2. Installed libffi-dev and libssl-dev in the RUN clause of the Dockerfile.
3. Added a check in the RUN clause of the Dockerfile, for downloading kubectl binary according to the
host platform.
4. Added architecture check in the Makefile, for adding architecture
along with the docker image tags.

Signed-off-by: odidev <odidev@puresoftware.com>
**Reviewer Comment :** < To be filled by Reviewer >

**Peer Reviewer:** Pruthvi Teja
**Reviewer:** Rajeev Nayan

**Thanks
Rahul Aggarwal**